### PR TITLE
Make the developing docs more visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ Each issue collects a variety of links.
 - **Opened Issues**
   - Issues which have just been opened might need a reproduction or could be fixed by you!
 
-## Want to Help?
-See [our development docs](/docs/developing.md)
+## Want to Help Maintain the Site?
+See [our development docs](/docs/developing.md).

--- a/README.md
+++ b/README.md
@@ -23,3 +23,6 @@ Each issue collects a variety of links.
   - Some PRs get opened each week. These afford the community the opportunity to get involved by running the relevant code and reviewing the PRs so code can be merged.
 - **Opened Issues**
   - Issues which have just been opened might need a reproduction or could be fixed by you!
+
+## Want to Help?
+See [our development docs](/docs/developing.md)


### PR DESCRIPTION
At the moment it's not entirely obvious where to find the relevant info on how to contribute, especially with how this site seems to use a lot of custom tech. Ideally it'd be in a `CONTRIBUTING.md` imo, but for now just linking to the current document in the `README.md` should help.